### PR TITLE
fix: curl_close() is deprecated in PHP 8.5 (no effect since PHP 8.0). Removing it.

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -56,7 +56,6 @@ class DataGetter {
 
 		$result   = curl_exec( $curl );
 		$httpCode = curl_getinfo( $curl, CURLINFO_HTTP_CODE );
-		curl_close( $curl );
 
 		if ( empty( $result ) ) {
 			$this->printResponse( "Server respond with empty data", self::STATUS_ERROR );


### PR DESCRIPTION
Otherwise /api was returning:

```
<br />
<b>Deprecated</b>:  Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in <b>/backend/index.php</b> on line <b>59</b><br />
<br />
<b>Warning</b>:  http_response_code(): Cannot set response code - headers already sent (output started at /backend/index.php:59) in <b>/backend/index.php</b> on line <b>45</b><br />
```

which was breaking the UI.